### PR TITLE
test name updated to match its assertion

### DIFF
--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception.cs
@@ -36,7 +36,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         }
 
         [Test]
-        public void should_be_two_failures()
+        public void should_be_three_failures()
         {
             classContext.Failures().Count().should_be(3);
         }


### PR DESCRIPTION
Minor issue: there was a test whose name referenced two failures while the test itself was looking for three.
