### PR TITLE
XUnit formatter and improvements to NSpecRunner

### DIFF
--- a/NSpec/Domain/Formatters/XUnitFormatter.cs
+++ b/NSpec/Domain/Formatters/XUnitFormatter.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace NSpec.Domain.Formatters
+{
+    [Serializable]
+    public class XUnitFormatter : IFormatter
+    {
+        public void Write(ContextCollection contexts)
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+            XmlTextWriter xml = new XmlTextWriter(sw);
+
+            xml.WriteStartElement("testsuites");
+            xml.WriteAttributeString("tests", contexts.Examples().Count().ToString());
+            xml.WriteAttributeString("errors", "0");
+            xml.WriteAttributeString("failures", contexts.Failures().Count().ToString());
+            xml.WriteAttributeString("skip", contexts.Pendings().Count().ToString());
+
+            contexts.Do(c => this.BuildContext(xml, c));
+            xml.WriteEndElement();
+
+            Console.WriteLine(sb.ToString());
+        }
+
+        void BuildContext(XmlTextWriter xml, Context context)
+        {
+            if (context.Level == 1)
+            {
+                xml.WriteStartElement("testsuite");
+                xml.WriteAttributeString("tests", context.AllExamples().Count().ToString());
+                xml.WriteAttributeString("name", context.Name);
+                xml.WriteAttributeString("errors", "0");
+                xml.WriteAttributeString("failures", context.Failures().Count().ToString());
+            }
+
+            context.Examples.Do(e => this.BuildSpec(xml, e));
+            context.Contexts.Do(c => this.BuildContext(xml, c));
+            
+            if (context.Level == 1)
+            {
+                xml.WriteEndElement();
+            }
+        }
+
+        void BuildSpec(XmlTextWriter xml, Example example)
+        {
+            xml.WriteStartElement("testcase");
+
+            string testName = example.Spec;
+			StringBuilder className = new StringBuilder();
+			ComposePartialName(example.Context, className);
+
+            xml.WriteAttributeString("classname", className.ToString());
+            xml.WriteAttributeString("name", testName);
+
+            if (example.Exception != null)
+            {                
+                xml.WriteStartElement("failure");
+                xml.WriteAttributeString("type", example.Exception.GetType().Name);
+                xml.WriteAttributeString("message", example.Exception.Message);
+                xml.WriteString(example.Exception.ToString());
+                xml.WriteEndElement();
+            }
+
+            xml.WriteEndElement();
+        }
+
+        private void ComposePartialName(Context context, StringBuilder contextName)
+        {
+			if (context.Level <= 1) { return; }
+
+			ComposePartialName(context.Parent, contextName);
+			if (contextName.Length > 0) { contextName.Append(", "); }
+
+			contextName.Append(context.Name);            
+        }
+    }
+}

--- a/NSpec/NSpec.csproj
+++ b/NSpec/NSpec.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Domain\Formatters\TiddlyWikiFormatter.cs" />
     <Compile Include="Domain\Extensions\DomainExtensions.cs" />
     <Compile Include="Domain\Formatters\XmlFormatter.cs" />
+    <Compile Include="Domain\Formatters\XUnitFormatter.cs" />
     <Compile Include="Domain\MethodContext.cs" />
     <Compile Include="Domain\ExceptionNotThrown.cs" />
     <Compile Include="DefaultConventions.cs" />

--- a/NSpecRunner/app.config
+++ b/NSpecRunner/app.config
@@ -1,3 +1,10 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+  </startup>
+  <runtime>
+    <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
+    <loadFromRemoteSources enabled="true"/>
+  </runtime>
+</configuration>


### PR DESCRIPTION
I've implemented a formatter that outputs XUnit-style XML (for use e.g. in Jenkins).  I also changed NSpecRunner so that you can specify the formatter to use on the command line.  A final change was made to allow NSpecRunner to load assemblies from network shares.
