### PR TITLE
Run nspecrunner in Single Threaded Apartment

### DIFF
--- a/NSpecRunner/Program.cs
+++ b/NSpecRunner/Program.cs
@@ -9,7 +9,7 @@ namespace NSpecRunner
 {
     class Program
     {
-
+        [STAThread]
         static void Main(string[] args)
         {
             if (args.Length == 0)


### PR DESCRIPTION
Execute runner in a single threaded apartment to allow tests to use
COM components.

Other test runners run in a single threaded apartment as well.

See mspec
https://github.com/machine/machine.specifications/blob/master/Source/Runners/Machine.Specifications.ConsoleRunner/Program.cs#L21

See nunit
https://github.com/nunit/nunit-console/blob/master/src/nunit-console/Program.cs#L40
