### PR TITLE
refactor(context): extract code capturing console output

### DIFF
--- a/sln/src/NSpec/Domain/ConsoleCatcher.cs
+++ b/sln/src/NSpec/Domain/ConsoleCatcher.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+
+namespace NSpec.Domain
+{
+    public class ConsoleCatcher : IDisposable
+    {
+        public ConsoleCatcher(Action<string> setOutput)
+        {
+            this.setOutput = setOutput;
+
+            stringWriter = new StringWriter();
+
+            lock (padlock)
+            {
+                stdout = Console.Out;
+                stderr = Console.Error;
+
+                Console.SetOut(stringWriter);
+                Console.SetError(stringWriter);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                lock (padlock)
+                {
+                    Console.SetOut(stdout);
+                    Console.SetError(stderr);
+                }
+
+                setOutput(stringWriter.ToString());
+
+                stringWriter.Dispose();
+
+                disposed = true;
+            }
+        }
+
+        bool disposed;
+
+        readonly Action<string> setOutput;
+        readonly StringWriter stringWriter;
+        readonly TextWriter stdout;
+        readonly TextWriter stderr;
+
+        static readonly object padlock = new object();
+    }
+}

--- a/sln/test/NSpec.Tests/describe_output.cs
+++ b/sln/test/NSpec.Tests/describe_output.cs
@@ -71,11 +71,11 @@ namespace NSpec.Tests
          TestCase(typeof(describe_focus_output),
                   new [] { typeof(describe_focus) },
                   "focus"),
-         TestCase(typeof(describe_output_capture_output),
-                    new[] { typeof(describe_output_capture) },
+         TestCase(typeof(describe_capturing_example_console_output),
+                    new[] { typeof(describe_capturing_example_console) },
                     ""),
-         TestCase(typeof(describe_context_output_capture_output),
-                    new[] { typeof(describe_context_output_capture) },
+         TestCase(typeof(describe_capturing_context_console_output),
+                    new[] { typeof(describe_capturing_context_console) },
                     "")]
 
         public void output_verification(Type output, Type []testClasses, string tags)

--- a/sln/test/Samples/SampleSpecs/WebSite/describe_capturing_context_console.cs
+++ b/sln/test/Samples/SampleSpecs/WebSite/describe_capturing_context_console.cs
@@ -1,7 +1,7 @@
 using System;
 using NSpec;
 
-public class describe_context_output_capture : nspec
+public class describe_capturing_context_console : nspec
 {
     void before_all()
     {
@@ -26,10 +26,10 @@ public class describe_context_output_capture : nspec
     }
 }
 
-public static class describe_context_output_capture_output
+public static class describe_capturing_context_console_output
 {
     public static string Output = @"
-describe context output capture
+describe capturing context console
 //Console output
 this is before all
   output capture

--- a/sln/test/Samples/SampleSpecs/WebSite/describe_capturing_example_console.cs
+++ b/sln/test/Samples/SampleSpecs/WebSite/describe_capturing_example_console.cs
@@ -1,7 +1,7 @@
 using System;
 using NSpec;
 
-public class describe_output_capture : nspec
+public class describe_capturing_example_console : nspec
 {
     void output_capture()
     {
@@ -12,10 +12,10 @@ public class describe_output_capture : nspec
     }
 }
 
-public static class describe_output_capture_output
+public static class describe_capturing_example_console_output
 {
     public static string Output = @"
-describe output capture
+describe capturing example console
   output capture
     should capture output (__ms)
       //Console output


### PR DESCRIPTION
This refactoring aims at:

* avoiding to repeat same code before and after console output must be captured
* applying well-known .NET metaphore of an IDisposable within a using() block