### PR TITLE
PR for issue #188

### DIFF
--- a/sln/src/NSpec/nspec.cs
+++ b/sln/src/NSpec/nspec.cs
@@ -288,6 +288,20 @@ namespace NSpec
         /// </summary>
         public readonly Func<Task> todoAsync = () => Task.Run(() => { });
 
+        public Action expectNoExceptions
+        {
+            get
+            {
+                var specContext = Context;
+
+                return () =>
+                {
+                    if (specContext.Exception != null)
+                        throw specContext.Exception;
+                };
+            }
+        }
+
         /// <summary>
         /// Set up an expectation for a particular exception type to be thrown before expectation.
         /// <para>For Example:</para>

--- a/sln/test/NSpec.Tests/WhenRunningSpecs/Exceptions/describe_expecting_no_exception_in_act.cs
+++ b/sln/test/NSpec.Tests/WhenRunningSpecs/Exceptions/describe_expecting_no_exception_in_act.cs
@@ -1,0 +1,60 @@
+﻿using FluentAssertions;
+using NSpec.Domain;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NSpec.Tests.WhenRunningSpecs.Exceptions
+{
+    [TestFixture]
+    [Category("RunningSpecs")]
+    [Tag("focus")]
+    public class describe_expecting_no_exception_in_act : when_expecting_no_exception_in_act
+    {
+        private class SpecClass : nspec
+        {
+            void method_level_context()
+            {
+                it["passes if no exception thrown"] = expectNoExceptions;
+
+                context["when exception thrown from act"] = () =>
+                {
+                    act = () => { throw new KnownException("unexpected failure"); };
+
+                    it["rethrows the exception from act"] = expectNoExceptions;
+                };
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+
+    }
+
+    public abstract class when_expecting_no_exception_in_act : when_running_specs
+    {
+        [Test]
+        public void should_be_one_failure()
+        {
+            classContext.Failures().Count().Should().Be(1);
+        }
+
+        [Test]
+        public void passes_if_no_exception_thrown()
+        {
+            TheExample("passes if no exception thrown").Exception.Should().BeNull();
+        }
+
+        [Test]
+        public void rethrows_the_exception_from_act()
+        {
+            var exception = TheExample("rethrows the exception from act").Exception;
+            
+            exception.Should().BeOfType<ExampleFailureException>();
+            exception.Message.Should().Be("Context Failure: unexpected failure, Example Failure: unexpected failure");
+        }
+    }
+}


### PR DESCRIPTION
PR for issue #188.

I've added a `expectNoExceptions` property that returns a lambda expression. It just rethrows the context exception, but I thought about wrapping it in custom exception to better express where it failed at. I wasn't sure where `Context Failure: unexpected failure, Example Failure: unexpected failure` is used as I've never noticed it in the console runner, so I'm unsure how it will present itself there.